### PR TITLE
Document pthread implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ threads.
   browsers).
 
 - __future-compatible__: a possible future direction for WebAssembly is towards
-  supporting multiple threads per instance. This is not possible with the
-  current memory model and instruction set. We aim to expose an API that would
+  supporting multiple threads per instance. We aim to expose an API that would
   be compatible with this future direction.
 
 - __browser polyfills__: for browsers, we aim to provide a way to polyfill this

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ the `pthread_t` structure. This could be implemented by the following steps
    parameters `int tid` and `void *start_args`
 4. in `pthread_create`, call `wasi_thread_spawn` with the configured
    `start_args` and use `atomic.wait` to wait for the `start_args->thread->tid`
-   value to change
+   value to change (note that for web polyfills this may not be necessary since
+   creation of web workers is not synchronous)
 5. now in the child thread: once the WASI host creates the new thread instance
    and calls `wasi_thread_start`, then a) set `args->thread->tid` to the
    host-provided `tid`, b) set the `__wasilibc_pthread_self` global to point to

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ threads.
 
 
 ### Non-goals
-- __not POSIX compatible__: this API will not be 100% compatible with all
+- __full POSIX compatibity__: this API will not be 100% compatible with all
   functions and options described by POSIX threads standard.
 
-- __no WebAssembly changes__: the current proposal is limited to the WASI APIs
+- __modify core WebAssembly__: the current proposal is limited to the WASI APIs
   signatures and behavior and does not propose changes to the Wasm instruction
   set.
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,16 @@ threads.
 
 ### API walk-through
 
-The API requires the addition of a single function. In pseudo-code:
+The API consists of a single function. In pseudo-code:
 
 ```C
-status thread_spawn(thread_start_func* start_func, thread_start_arg* start_arg);
+status wasi_thread_spawn(thread_start_arg* start_arg);
 ```
 
-Any necessary locking/signaling/thread-local storage will be implemented using
-existing instructions available in WebAssembly. Ideally, users will never use
+The host implementing `wasi_thread_spawn` will call a predetermined function
+export (`wasi_thread_start`) in a new WebAssembly instance. Any necessary
+locking/signaling/thread-local storage will be implemented using existing
+instructions available in WebAssembly. Ideally, users will never use
 `thread_spawn` directly but rather compile their threaded code from a language
 that supports threads (see below).
 
@@ -202,6 +204,12 @@ and what can safely be skipped until some later date.
   implementation. It can be left for later.
 
 [deprecated]: https://man7.org/linux/man-pages/man3/pthread_yield.3.html
+
+##### What _has_ been implemented
+
+`wasi-libc` contains an implementation of `pthreads` using `wasi-threads`. The
+implementation is currently in progress: see the [list of threads-related
+PRs](https://github.com/WebAssembly/wasi-libc/pulls?q=is%3Apr+threads).
 
 #### Design choice: instance-per-thread
 

--- a/README.md
+++ b/README.md
@@ -200,10 +200,10 @@ and what can safely be skipped until some later date.
 - `pthread_yield` is a [deprecated] `pthreads` function; `sched_yield` is the
   right one to use. Since it is unclear how WASI's scheduling should interact
   with the host's, this can be deferred until someone has a use case for it.
-- `pthread_cancel` allows a parent thread to cancel a child thread; this
-  functionality is difficult (impossible?) to implement without a WebAssembly
-  mechanism to interrupt the child thread and complicates the entire
-  implementation. It can be left for later.
+- `pthread_cancel` allows a parent thread to cancel a child thread; in
+  particular, asynchronous cancellation is difficult (impossible?) to implement
+  without a WebAssembly mechanism to interrupt the child thread and it
+  complicates the entire implementation. It can be left for later.
 
 [deprecated]: https://man7.org/linux/man-pages/man3/pthread_yield.3.html
 


### PR DESCRIPTION
This change is a wide-ranging edit of `README.md`. It started as simply my explanation of how to implement `pthread_create` motivated by my work in `wasi-libc`. Once I started changing `thread_spawn` to accommodate what would be necessary there, though, I started re-explaining certain sections, fixing typos, broken links, etc.