### PR TITLE
Tweak API title in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Native Threads API
+# `wasi-threads`
 
 A proposed [WebAssembly System Interface](https://github.com/WebAssembly/WASI)
 API to add native thread support.


### PR DESCRIPTION
Since the repository is now named `wasi-threads`, this change reflects that instead of the original "native" terminology.