### PR TITLE
Add clarification for the return value of the `wasi_thread_spawn` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The API consists of a single function. In pseudo-code:
 status wasi_thread_spawn(thread_start_arg* start_arg);
 ```
 
+where the `status` is a unique non-negative integer thread ID of the new
+thread or negative number representing an error in case the thread failed to
+start.
 The host implementing `wasi_thread_spawn` will call a predetermined function
 export (`wasi_thread_start`) in a new WebAssembly instance. Any necessary
 locking/signaling/thread-local storage will be implemented using existing


### PR DESCRIPTION
The documentation here was a bit vague; libc implementation alread assumed the return value to be a thread id; this is similar to posix's `clone`.

I think using return value for thread ID makes sense in WASI, but I'm open for discussion.