### PR TITLE
Set longer timeout for poll_oneoff

### DIFF
--- a/test/testsuite/wasi_threads_exit_main_wasi.wat
+++ b/test/testsuite/wasi_threads_exit_main_wasi.wat
@@ -16,7 +16,7 @@
     ;; long enough block
     ;; clock_realtime, !abstime (zeros)
     i32.const 124 ;; 100 + offsetof(subscription, timeout)
-    i64.const 1_000_000_000 ;; 1s
+    i64.const 2_000_000_000 ;; 2s
     i64.store
     i32.const 100 ;; subscription
     i32.const 200 ;; event (out)

--- a/test/testsuite/wasi_threads_exit_nonmain_wasi.wat
+++ b/test/testsuite/wasi_threads_exit_nonmain_wasi.wat
@@ -42,7 +42,7 @@
     ;; long enough block
     ;; clock_realtime, !abstime (zeros)
     i32.const 124 ;; 100 + offsetof(subscription, timeout)
-    i64.const 1_000_000_000 ;; 1s
+    i64.const 2_000_000_000 ;; 2s
     i64.store
     i32.const 100 ;; subscription
     i32.const 200 ;; event (out)


### PR DESCRIPTION
Relaxing the timeout for `poll_oneoff`.
While executing the tests in [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime), I see that that 1 second is not enough, i.e. the timeout finished before the `proc_exit` propagation happens.