### PR TITLE
Fix race condition in test

### DIFF
--- a/test/testsuite/thread_spawn-simple.c
+++ b/test/testsuite/thread_spawn-simple.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
         assert(data[i].tid == tid[i]);
         assert(data[i].value == 60);
 
-        for (j = i + 1; j < data_count; j++)
+        for (j = 0; j < i; j++)
         {
             assert(data[i].tid != data[j].tid);
         }


### PR DESCRIPTION
In the assertion to check TID uniqueness, https://github.com/WebAssembly/wasi-threads/blob/c1b421c2158b745c840b5bdca98ed870c2a6d11a/test/testsuite/thread_spawn-simple.c#L73 the data of a thread not yet "done" should not be accessed.