### PR TITLE
add a test case which doesn't even import wasi:thread-spawn

### DIFF
--- a/test/testsuite/wasi_threads_noop.wat
+++ b/test/testsuite/wasi_threads_noop.wat
@@ -1,0 +1,6 @@
+;; Minimum valid command for wasi-threads.
+
+(module
+  (memory (export "memory") (import "foo" "bar") 0 0 shared)
+  (func (export "_start"))
+)


### PR DESCRIPTION
passed:
    toywasm
    wamr
    wasmer

failed:
    wasmtime (15.0.1)