### PR TITLE
Note the state of the proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ API to add native thread support.
 > on threads will happen in the [shared-everything-threads] proposal which adds
 > component model [built-ins] for thread spawning, among other things. The goal
 > is that WASI v0.2 and following will use [shared-everything-threads] (once
-> fully implemented) and this proposal can eventually be removed.
+> fully implemented) and this proposal can eventually be removed. In the
+> meantime, users experimenting with this proposal can continue to get help
+> with questions and bugs by opening issues on this repository and tagging
+> various WAMR maintainers who plan to continue supporting WASI v0.1 (e.g.,
+> @loganek, @yamt, @wenyongh).
 
 [shared-everything-threads]: https://github.com/WebAssembly/shared-everything-threads
 [built-ins]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#-threads

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 A proposed [WebAssembly System Interface](https://github.com/WebAssembly/WASI)
 API to add native thread support.
 
+> __NOTE__: this proposal is considered a legacy proposal, retained for engines
+> that can only support WASI v0.1 (`preview1`). After much debate, future work
+> on threads will happen in the [shared-everything-threads] proposal which adds
+> component model [built-ins] for thread spawning, among other things. The goal
+> is that WASI v0.2 and following will use [shared-everything-threads] (once
+> fully implemented) and this proposal can eventually be removed.
+
+[shared-everything-threads]: https://github.com/WebAssembly/shared-everything-threads
+[built-ins]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#-threads
+
 ### Current Phase
 
 Phase 1


### PR DESCRIPTION
The CG has reached agreement that the future of threads in WebAssembly goes through the shared-everything-threads proposal. This change tries to communicate the "legacy" nature of wasi-threads: still valuable in some cases but planned for eventual deprecation.