### PR TITLE
Update implementation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ API to add native thread support.
 > component model [built-ins] for thread spawning, among other things. The goal
 > is that WASI v0.2 and following will use [shared-everything-threads] (once
 > fully implemented) and this proposal can eventually be removed. In the
-> meantime, users experimenting with this proposal can continue to get help
-> with questions and bugs by opening issues on this repository and tagging
-> various WAMR maintainers who plan to continue supporting WASI v0.1 (e.g.,
-> @loganek, @yamt, @wenyongh).
+> meantime, users experimenting with this proposal can continue to get help with
+> questions and bugs by opening issues on this repository and tagging various
+> maintainers who plan to continue supporting WASI v0.1 (e.g., @loganek, @yamt,
+> @wenyongh).
 
 [shared-everything-threads]: https://github.com/WebAssembly/shared-everything-threads
 [built-ins]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#-threads
@@ -259,9 +259,9 @@ and what can safely be skipped until some later date.
 
 ##### What _has_ been implemented
 
-`wasi-libc` contains an implementation of `pthreads` using `wasi-threads`. The
-implementation is currently in progress: see the [list of threads-related
-PRs](https://github.com/WebAssembly/wasi-libc/pulls?q=is%3Apr+threads).
+`wasi-libc` contains an implementation of `pthreads` using
+`wasi-threads`. Various WebAssembly engines support the proposal, including:
+Wasmtime, WAMR, Wasmer, toywasm.
 
 #### Design choice: instance-per-thread
 


### PR DESCRIPTION
As suggested by @yamt in a [comment], it may be better to avoid highlighting WAMR exclusively in the top-level "warning." Instead, this updates the implementation status for known engines.

[comment]: https://github.com/WebAssembly/wasi-threads/pull/50#discussion_r1675304212